### PR TITLE
restore kernel default coredump pattern

### DIFF
--- a/usr/lib/sysctl.d/00-coredump-defaults-openSUSE.conf
+++ b/usr/lib/sysctl.d/00-coredump-defaults-openSUSE.conf
@@ -1,0 +1,3 @@
+# restore kernel default pattern as systemd overrides it early at
+# boot https://github.com/systemd/systemd/pull/26607
+kernel.core_pattern=core

--- a/usr/lib/systemd/system.conf.d/__20-coredump-defaults-openSUSE.conf
+++ b/usr/lib/systemd/system.conf.d/__20-coredump-defaults-openSUSE.conf
@@ -1,0 +1,4 @@
+# restore kernel default settings as systemd touches coredump handling early
+# https://github.com/systemd/systemd/pull/26607
+[Manager]
+DefaultLimitCORE=0:infinity


### PR DESCRIPTION
Systemd overrides the coredump pattern early at boot even if
systemd-coredump is not installed

https://github.com/systemd/systemd/pull/26607
