### PR TITLE
user@.service: Disable controllers by default

### DIFF
--- a/usr/lib/systemd/system/user@.service.d/20-defaults-SUSE.conf
+++ b/usr/lib/systemd/system/user@.service.d/20-defaults-SUSE.conf
@@ -7,7 +7,7 @@
 # than 70).
 
 [Service]
-# Delegation for privileged services is supposed to enable all or
-# listed resource controllers, which would incur performance penalties
-# to *all* running services (bsc#954765 jsc#PM-2229).
-Delegate=no
+# Disable controller delegation for user services, controllers would incur
+# performance penalties to *all* running services (bsc#954765 jsc#PM-2229
+# jsc#PED-2276).
+Delegate=


### PR DESCRIPTION
The switch to cgroup v2 means that controller delegation is permitted for any user (not only uid=0) within systemd.
Performance penalties are still measurable (as of ~v6.4 kernel), so the want to keep controller still disabled.
Extend the drop-in to any user's user@.service (needed for unified setup and it achieves original effect for hybrid hierarchy). Instead of straight 'no', use "empty list" of controllers (implemented since v236) because unprivileged users still need to access their cgroup.procs file.

A possible alternative would be to DisableControllers= on a ancestral units of user@.services. But: a) it needs explicit list of all of them, b) we only want to affect the default (without preventing lazy enablement of controllers when user e.g. sets up a memory limit on user@uid.service).

[mkoutny: fixes jsc#PED-2276]